### PR TITLE
add git to output image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ COPY --from=build /go/terraform /usr/bin
 COPY --from=build /go/bin/terraform-docs /usr/bin
 COPY --from=build /go/tflint /usr/bin
 COPY --from=build /go/bin/cred-alert /usr/bin
-RUN apk add --no-cache python3
+RUN apk add --no-cache python3 && apk add --no-cache git
 RUN pip3 install --no-cache-dir terrascan tf-readme-validator

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,4 @@ COPY --from=build /go/terraform /usr/bin
 COPY --from=build /go/bin/terraform-docs /usr/bin
 COPY --from=build /go/tflint /usr/bin
 COPY --from=build /go/bin/cred-alert /usr/bin
-RUN apk add --no-cache python3 && apk add --no-cache git
-RUN pip3 install --no-cache-dir terrascan tf-readme-validator
+RUN apk add --no-cache python3 git && pip3 install --no-cache-dir terrascan tf-readme-validator


### PR DESCRIPTION
fix [this](https://travis-ci.org/lean-delivery/tf-module-static-artifact-storage/builds/501900878):
```
Status: Downloaded newer image for leandelivery/docker-terraform-ci:latest
Initializing modules...
- module.vpc
  Getting source "github.com/lean-delivery/tf-module-awscore"
Error downloading modules: Error loading modules: error downloading 'https://github.com/lean-delivery/tf-module-awscore.git': git must be available and on the PATH
The command "docker run --rm -v $(pwd):/work/ --workdir=/work/ -t leandelivery/docker-terraform-ci terraform init" exited with 1.
```